### PR TITLE
fix(docker): Correct `uv run` command in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN useradd --create-home --uid 1000 appuser && \
     chown -R appuser:appuser /app
 USER appuser
 
-CMD ["uv", "run", "alpaca_mcp_server.py"]
+CMD ["uv", "run", "python", "alpaca_mcp_server.py"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,5 +21,5 @@ services:
       timeout: 5s
       retries: 2
       start_period: 5s
-    # Development-specific command for live reloading
-    command: ["uv", "run", "--reload", "alpaca_mcp_server.py"]
+    # Development-specific command
+    command: ["uv", "run", "python", "alpaca_mcp_server.py"]


### PR DESCRIPTION
The `uv run` command requires `python` to be specified when running a script. This was causing an error when starting the application with Docker.

This commit updates the `Dockerfile` and `docker-compose.override.yml` to use the correct `uv run python alpaca_mcp_server.py` command.

Additionally, the `--reload` flag has been removed from the development override to simplify the development environment setup.